### PR TITLE
Feat/participant

### DIFF
--- a/apps/api/src/main/kotlin/org/aiml/api/controller/PublicController.kt
+++ b/apps/api/src/main/kotlin/org/aiml/api/controller/PublicController.kt
@@ -1,6 +1,5 @@
 package org.aiml.api.controller
 
-import jakarta.websocket.server.PathParam
 import org.aiml.api.common.response.ApiResponse
 import org.aiml.api.common.response.ok
 import org.aiml.api.dto.scene.SceneResponse
@@ -8,6 +7,7 @@ import org.aiml.scene.application.facade.SceneQueryFacade
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
@@ -18,7 +18,7 @@ class PublicController(
 ) {
   @GetMapping("/scene")
   fun getPublicProjectScenes(
-    @PathParam("pId") pId: UUID,
+    @RequestParam("pId") pId: UUID,
   ): ResponseEntity<ApiResponse<List<SceneResponse>>> {
     val scenes = sceneQueryFacade.loadPublicScene(pId)
     return ok(scenes.map { SceneResponse.fromDTO(it) })

--- a/modules/project-user/src/main/kotlin/org/aiml/project_user/application/ProjectUserCommandServiceImpl.kt
+++ b/modules/project-user/src/main/kotlin/org/aiml/project_user/application/ProjectUserCommandServiceImpl.kt
@@ -29,7 +29,7 @@ class ProjectUserCommandServiceImpl(
   }
 
   override fun deleteAllByUserId(userId: UUID) {
-    TODO("Not yet implemented")
+    return projectUserCommandPort.deleteAllProjectUserByProjectId(userId).getOrThrow()
   }
 
   override fun deleteAll() {

--- a/modules/project-user/src/main/kotlin/org/aiml/project_user/application/facade/ParticipantService.kt
+++ b/modules/project-user/src/main/kotlin/org/aiml/project_user/application/facade/ParticipantService.kt
@@ -1,5 +1,6 @@
 package org.aiml.project_user.application.facade
 
+import jakarta.transaction.Transactional
 import org.aiml.project_user.application.ProjectUserAuthService
 import org.aiml.project_user.application.dto.ProjectUserDTO
 import org.aiml.project_user.application.dto.ProjectUserNameDTO
@@ -32,6 +33,7 @@ class ParticipantService(
     return ProjectUserNameDTO.from(pUser, user.username)
   }
 
+  @Transactional
   fun removeParticipant(userId: UUID, projectId: UUID, username: String) {
     authService.authenticateOwner(userId, projectId)
     val user = findUser(username)

--- a/modules/project-user/src/main/kotlin/org/aiml/project_user/domain/port/outbound/ProjectUserCommandPort.kt
+++ b/modules/project-user/src/main/kotlin/org/aiml/project_user/domain/port/outbound/ProjectUserCommandPort.kt
@@ -9,5 +9,7 @@ interface ProjectUserCommandPort {
   fun deleteByProjectIdAndUserId(projectId: UUID, userId: UUID): Result<Unit>
   fun deleteAllProjectUserByProjectId(projectId: UUID): Result<Unit>
 
+  fun deleteAllByUserId(userId: UUID): Result<Unit>
+
   fun deleteAll(): Result<Unit>
 }

--- a/modules/project-user/src/main/kotlin/org/aiml/project_user/infra/adapter/ProjectUserCommandAdapter.kt
+++ b/modules/project-user/src/main/kotlin/org/aiml/project_user/infra/adapter/ProjectUserCommandAdapter.kt
@@ -45,6 +45,12 @@ class ProjectUserCommandAdapter(
     }
   }
 
+  override fun deleteAllByUserId(userId: UUID): Result<Unit> {
+    return runCatching {
+      projectUserRepository.deleteAllByUserId(userId)
+    }
+  }
+
   override fun deleteAll(): Result<Unit> = runCatching {
     projectUserRepository.deleteAll()
   }

--- a/modules/project-user/src/main/kotlin/org/aiml/project_user/infra/persistence/repository/ProjectUserRepository.kt
+++ b/modules/project-user/src/main/kotlin/org/aiml/project_user/infra/persistence/repository/ProjectUserRepository.kt
@@ -13,7 +13,7 @@ interface ProjectUserRepository : JpaRepository<ProjectUserEntity, UUID> {
   fun findByProjectIdAndUserId(projectId: UUID, userId: UUID): Optional<ProjectUserEntity>
   fun deleteByProjectIdAndUserId(projectId: UUID, userId: UUID)
 
-  @Modifying(clearAutomatically = true)
-  @Transactional
+
   fun deleteAllByProjectId(projectId: UUID)
+  fun deleteAllByUserId(userId: UUID)
 }


### PR DESCRIPTION
1. participant 삭제
projectUserRepository.deleteByProjectIdAndUserId(projectId, userId)에 트랜잭션이 걸려있지 않음.
service 차원에서 트랜잭션 처리

2. 
TODO Impl deleteAllByUserId

*
기존의 repository 차원에서의 트랜잭션 처리 삭제




