### PR TITLE
fix userProfile update and file delete processing

### DIFF
--- a/apps/api/src/main/kotlin/org/aiml/api/controller/UserController.kt
+++ b/apps/api/src/main/kotlin/org/aiml/api/controller/UserController.kt
@@ -52,6 +52,14 @@ class UserController(
     return ok(UserProfileResponse.from(user, fileStorage))
   }
 
+  @DeleteMapping("/me/image")
+  fun deleteUserProfile(
+    @AuthenticationPrincipal principal: CustomUserPrincipal,
+  ): ResponseEntity<ApiResponse<Nothing>> {
+    userProfileCommandService.deleteImageByUserId(principal.userId) // ?
+    return deleted()
+  }
+
   @DeleteMapping("/me")
   fun deleteUser(
     @AuthenticationPrincipal principal: CustomUserPrincipal,

--- a/libs/common/src/main/kotlin/org/aiml/libs/common/file/FileStorage.kt
+++ b/libs/common/src/main/kotlin/org/aiml/libs/common/file/FileStorage.kt
@@ -4,5 +4,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 interface FileStorage {
   fun uploadFile(file: MultipartFile, path: String): String
+  fun deleteFile(path: String): Unit
   fun getUrl(path: String?): String
 }

--- a/libs/common/src/main/kotlin/org/aiml/libs/common/file/s3/S3FileStorage.kt
+++ b/libs/common/src/main/kotlin/org/aiml/libs/common/file/s3/S3FileStorage.kt
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import java.time.Duration
 
 @Component
@@ -31,6 +32,15 @@ class S3FileStorage(
     s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.inputStream, file.size))
 
     return putObjectRequest.key()
+  }
+
+  override fun deleteFile(path: String): Unit {
+    val deleteObjectRequest = DeleteObjectRequest.builder()
+      .bucket(bucketName)
+      .key(path)
+      .build()
+
+    s3Client.deleteObject(deleteObjectRequest)
   }
 
   override fun getUrl(path: String?): String {

--- a/modules/user/src/main/kotlin/org/aiml/user/application/command/UserProfileCommandServiceImpl.kt
+++ b/modules/user/src/main/kotlin/org/aiml/user/application/command/UserProfileCommandServiceImpl.kt
@@ -31,6 +31,13 @@ class UserProfileCommandServiceImpl(
     return UserProfileDTO.from(profile)
   }
 
+  override fun deleteImageByUserId(userId: UUID) {
+    // Update the user profile to remove the image URL
+    val filePath = userProfilePersistencePort.deleteImageByUserId(userId).getOrThrow()
+    // Delete the image file from S3
+    userFilePort.deleteProfilePicture(filePath).getOrThrow()
+  }
+
   override fun deleteByUserId(userId: UUID) {
     userProfilePersistencePort.deleteByUserId(userId).getOrThrow()
   }

--- a/modules/user/src/main/kotlin/org/aiml/user/domain/port/inbound/UserProfileCommandService.kt
+++ b/modules/user/src/main/kotlin/org/aiml/user/domain/port/inbound/UserProfileCommandService.kt
@@ -8,6 +8,8 @@ interface UserProfileCommandService {
   fun create(dto: UserProfileDTO): UserProfileDTO
   fun update(dto: UserProfileDTO, file: MultipartFile?): UserProfileDTO
 
+  fun deleteImageByUserId(userId: UUID)
+
   fun deleteByUserId(userId: UUID)
 
   fun deleteAll()

--- a/modules/user/src/main/kotlin/org/aiml/user/domain/port/outbound/UserFilePort.kt
+++ b/modules/user/src/main/kotlin/org/aiml/user/domain/port/outbound/UserFilePort.kt
@@ -5,4 +5,5 @@ import java.util.*
 
 interface UserFilePort {
   fun uploadProfilePicture(userId: UUID, file: MultipartFile): Result<String>
+  fun deleteProfilePicture(filePath: String): Result<Unit>
 }

--- a/modules/user/src/main/kotlin/org/aiml/user/domain/port/outbound/UserProfilePersistencePort.kt
+++ b/modules/user/src/main/kotlin/org/aiml/user/domain/port/outbound/UserProfilePersistencePort.kt
@@ -14,6 +14,7 @@ interface UserProfilePersistencePort {
   fun findByUserId(userId: UUID): Result<UserProfile?>
 //  fun findByUsername(username: String): Result<UserProfile?>
 
+  fun deleteImageByUserId(userId: UUID): Result<String>
 
   fun deleteAll(): Result<Unit>
 }

--- a/modules/user/src/main/kotlin/org/aiml/user/infra/adapter/UserFileAdapter.kt
+++ b/modules/user/src/main/kotlin/org/aiml/user/infra/adapter/UserFileAdapter.kt
@@ -27,4 +27,16 @@ class UserFileAdapter(
       Result.failure(e)
     }
   }
+
+  override fun deleteProfilePicture(filePath: String): Result<Unit> {
+    return try {
+      // Delete the file using the file storage service
+      fileStorage.deleteFile(filePath)  // amazonS3.deleteObject(new DeleteObjectRequest(bucket, key));
+
+      Result.success(Unit)
+    } catch (e: Exception) {
+      // Handle any exceptions that occur during file deletion
+      Result.failure(e)
+    }
+  }
 }

--- a/modules/user/src/main/kotlin/org/aiml/user/infra/adapter/UserProfilePersistenceAdapter.kt
+++ b/modules/user/src/main/kotlin/org/aiml/user/infra/adapter/UserProfilePersistenceAdapter.kt
@@ -25,10 +25,10 @@ class UserProfilePersistenceAdapter(
     val existing = userProfileRepository.findByUserId(profile.userId)
     if(existing != null) {
       val update = existing.copy(
-        firstName = profile.firstName,
-        lastName = profile.lastName,
-        bio = profile.bio,
-        imageUrl = profile.imageUrl,
+        firstName = profile.firstName ?: existing.firstName,
+        lastName = profile.lastName ?: existing.lastName,
+        bio = profile.bio ?: existing.bio,
+        imageUrl = profile.imageUrl ?: existing.imageUrl,
         )
       userProfileRepository.save(update).toDomain()
     } else {
@@ -36,6 +36,19 @@ class UserProfilePersistenceAdapter(
       userProfileRepository.save(entity).toDomain()
     }
   }
+
+  override fun deleteImageByUserId(userId: UUID): Result<String> = runCatching {
+    val existing = userProfileRepository.findByUserId(userId)
+    val imageUrl = existing?.imageUrl
+    if (existing != null) {
+      val updated = existing.copy(imageUrl = null)
+      userProfileRepository.save(updated).toDomain()
+    } else {
+      throw NoSuchElementException("User profile not found for userId: $userId")
+    }
+    imageUrl ?: throw NoSuchElementException("Image URL not found for userId: $userId")
+  }
+
 
 
   // query


### PR DESCRIPTION
### update profile 내부 로직 변경

Before
: properties 그대로 db에 반영

Problem
: upload할 파일이 없으면 결과적으로 delete File로 처리됨

After
: properties의 null에 따라 db에 업데이트가 될 수 있도록 반영하고, 파일 삭제를 위한 인터페이스 작성

for delete file, request "Delete {{url}}/api/user/me/image"

